### PR TITLE
fix/cmderr

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: "go-install-test"
 run-name: "go-install-test"
 on:
   push:
-    branches: fix/cmderr
+    branches: master
 
 jobs:
   test:
@@ -14,7 +14,7 @@ jobs:
           echo -e "module github.com/jake-young-dev/go-install-script\n\ngo 1.23.5" > go.mod
 
       - name: "run go install script"
-        uses: jake-young-dev/go-install-script@fix/cmderr
+        uses: jake-young-dev/go-install-script@master
         with:
           architecture: amd64
           overwrite: yes #removes old go versions if present (github hosted runners come preloaded with go)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: "go-install-test"
 run-name: "go-install-test"
 on:
   push:
-    branches: master
+    branches: fix/cmderr
 
 jobs:
   test:
@@ -14,7 +14,7 @@ jobs:
           echo -e "module github.com/jake-young-dev/go-install-script\n\ngo 1.23.5" > go.mod
 
       - name: "run go install script"
-        uses: jake-young-dev/go-install-script@master
+        uses: jake-young-dev/go-install-script@fix/cmderr
         with:
           architecture: amd64
           overwrite: yes #removes old go versions if present (github hosted runners come preloaded with go)

--- a/go.sh
+++ b/go.sh
@@ -19,7 +19,7 @@ DL_VSPL=( $DL_VERSION_RAW )
 DL_VERSION="${DL_VSPL[1]}"
 
 #check if go is already present before starting install process
-GO_CHECK=$(go version)
+GO_CHECK=$(command -v go)
 if [[ "$GO_CHECK" ]]; then
   #if overwrite flag is set remove old go files
   if [[ "$2" == "yes" ]]; then


### PR DESCRIPTION
moved to check for go with command -v to prevent an error response when old versions aren't present